### PR TITLE
security: PR-1 quick-wins — perms, lock canonicalization, K8s securityContext

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -40,7 +40,7 @@ func NewInitCommand() *cobra.Command {
 			// Create subdirectories
 			for _, sub := range subdirs {
 				full := filepath.Join(dir, sub)
-				if err := os.MkdirAll(full, 0o755); err != nil {
+				if err := os.MkdirAll(full, 0o700); err != nil {
 					return fmt.Errorf("cannot create %s: %w", full, err)
 				}
 				fmt.Fprintf(cmd.OutOrStdout(), "✓ %s\n", full)
@@ -58,7 +58,7 @@ func NewInitCommand() *cobra.Command {
 				if err != nil {
 					return err
 				}
-				if err := os.WriteFile(cfgPath, data, 0o644); err != nil {
+				if err := os.WriteFile(cfgPath, data, 0o600); err != nil {
 					return fmt.Errorf("cannot write config.yaml: %w", err)
 				}
 				fmt.Fprintf(cmd.OutOrStdout(), "✓ %s\n", cfgPath)

--- a/cmd/record.go
+++ b/cmd/record.go
@@ -91,7 +91,7 @@ func NewRecordCommand() *cobra.Command {
 
 			// Create service-records dir if needed
 			srDir := filepath.Join(adir, "service-records")
-			if err := os.MkdirAll(srDir, 0755); err != nil {
+			if err := os.MkdirAll(srDir, 0o700); err != nil {
 				return fmt.Errorf("cannot create service-records directory: %w", err)
 			}
 
@@ -123,7 +123,7 @@ func NewRecordCommand() *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("cannot marshal service record: %w", err)
 			}
-			if err := os.WriteFile(srFile, out, 0644); err != nil {
+			if err := os.WriteFile(srFile, out, 0o600); err != nil {
 				return fmt.Errorf("cannot write service record: %w", err)
 			}
 

--- a/cmd/research.go
+++ b/cmd/research.go
@@ -49,7 +49,7 @@ func NewResearchCommand() *cobra.Command {
 
 			// Create drafts subdirectory
 			draftsDir := filepath.Join(pdir, "drafts")
-			if err := os.MkdirAll(draftsDir, 0o755); err != nil {
+			if err := os.MkdirAll(draftsDir, 0o700); err != nil {
 				return fmt.Errorf("cannot create drafts directory %s: %w", draftsDir, err)
 			}
 
@@ -58,7 +58,7 @@ func NewResearchCommand() *cobra.Command {
 			draftPath := filepath.Join(draftsDir, filename)
 
 			content := buildResearchPrompt(role, today)
-			if err := os.WriteFile(draftPath, []byte(content), 0o644); err != nil {
+			if err := os.WriteFile(draftPath, []byte(content), 0o600); err != nil {
 				return fmt.Errorf("cannot write draft file %s: %w", draftPath, err)
 			}
 

--- a/cmd/seed.go
+++ b/cmd/seed.go
@@ -23,7 +23,7 @@ func NewSeedCommandFS(generalsFS fs.FS) *cobra.Command {
 			if profilesDir == "" {
 				return fmt.Errorf("--profiles-dir is required")
 			}
-			if err := os.MkdirAll(profilesDir, 0o755); err != nil {
+			if err := os.MkdirAll(profilesDir, 0o700); err != nil {
 				return fmt.Errorf("cannot create profiles directory: %w", err)
 			}
 
@@ -50,7 +50,7 @@ func NewSeedCommandFS(generalsFS fs.FS) *cobra.Command {
 				if err != nil {
 					return err
 				}
-				if err := os.WriteFile(dest, data, 0o644); err != nil {
+				if err := os.WriteFile(dest, data, 0o600); err != nil {
 					return fmt.Errorf("cannot write %s: %w", dest, err)
 				}
 				installed++

--- a/docker/nginx-docs.conf
+++ b/docker/nginx-docs.conf
@@ -1,3 +1,7 @@
+# INVARIANT: this config serves static files only.
+# Do NOT add proxy_pass, autoindex, CGI/FastCGI, or any dynamic content directive.
+# The docs pod is deployed in-cluster; a dynamic directive here becomes an SSRF pivot.
+# See GitHub issue #51 for audit record.
 server {
     listen 8080;
     server_name _;

--- a/internal/sync/sync.go
+++ b/internal/sync/sync.go
@@ -3,7 +3,6 @@ package sync
 import (
 	"fmt"
 	"net/url"
-	"path/filepath"
 	"strings"
 
 	"github.com/petersimmons1972/armies/internal/gitops"
@@ -57,8 +56,7 @@ func Sync(opts SyncOptions) SyncResult {
 		return errResult(err.Error())
 	}
 
-	lockPath := filepath.Join(opts.ArmiesDir, ".sync.lock")
-	lf, err := acquireLock(lockPath)
+	lf, err := acquireLock(opts.ArmiesDir, ".sync.lock")
 	if err != nil {
 		return errResult(err.Error())
 	}

--- a/internal/sync/sync_lock_stub.go
+++ b/internal/sync/sync_lock_stub.go
@@ -4,5 +4,5 @@ package sync
 
 import "os"
 
-func acquireLock(path string) (*os.File, error) { return nil, nil }
-func releaseLock(f *os.File)                    {}
+func acquireLock(dir, name string) (*os.File, error) { return nil, nil }
+func releaseLock(f *os.File)                         {}

--- a/internal/sync/sync_lock_unix.go
+++ b/internal/sync/sync_lock_unix.go
@@ -4,13 +4,37 @@ package sync
 
 import (
 	"fmt"
+	"log"
 	"os"
+	"path/filepath"
+	"strings"
 
 	"golang.org/x/sys/unix"
 )
 
-func acquireLock(path string) (*os.File, error) {
-	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY, 0600)
+// acquireLock opens and flock()s a lock file named `name` inside `dir`.
+// The lock path is canonicalized against `dir` (symlinks resolved) and verified
+// to lie inside `dir` before open, so a caller cannot be tricked into creating
+// a lock file at an arbitrary filesystem location via a symlinked dir.
+func acquireLock(dir, name string) (*os.File, error) {
+	if strings.ContainsRune(name, filepath.Separator) || name == "" || name == "." || name == ".." {
+		return nil, fmt.Errorf("invalid lock name %q", name)
+	}
+	realDir, err := filepath.EvalSymlinks(dir)
+	if err != nil {
+		return nil, fmt.Errorf("resolve lock dir %q: %w", dir, err)
+	}
+	absDir, err := filepath.Abs(realDir)
+	if err != nil {
+		return nil, fmt.Errorf("abs lock dir %q: %w", realDir, err)
+	}
+	path := filepath.Join(absDir, name)
+	rel, err := filepath.Rel(absDir, path)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return nil, fmt.Errorf("lock path %q escapes dir %q", path, absDir)
+	}
+
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY, 0o600)
 	if err != nil {
 		return nil, fmt.Errorf("open sync lock %q: %w", path, err)
 	}
@@ -25,6 +49,10 @@ func releaseLock(f *os.File) {
 	if f == nil {
 		return
 	}
-	unix.Flock(int(f.Fd()), unix.LOCK_UN)
-	f.Close()
+	if err := unix.Flock(int(f.Fd()), unix.LOCK_UN); err != nil {
+		log.Printf("sync: flock(LOCK_UN) failed on %s: %v", f.Name(), err)
+	}
+	if err := f.Close(); err != nil {
+		log.Printf("sync: close lock file %s failed: %v", f.Name(), err)
+	}
 }

--- a/internal/sync/sync_lock_unix_test.go
+++ b/internal/sync/sync_lock_unix_test.go
@@ -1,0 +1,59 @@
+//go:build linux || darwin
+
+package sync
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestAcquireLock_RejectsSeparatorInName(t *testing.T) {
+	dir := t.TempDir()
+	for _, name := range []string{"../evil", "sub/evil", "", ".", ".."} {
+		if _, err := acquireLock(dir, name); err == nil {
+			t.Errorf("expected error for name %q, got nil", name)
+		}
+	}
+}
+
+func TestAcquireLock_CreatesInsideDir(t *testing.T) {
+	dir := t.TempDir()
+	f, err := acquireLock(dir, ".sync.lock")
+	if err != nil {
+		t.Fatalf("acquireLock: %v", err)
+	}
+	defer releaseLock(f)
+
+	want := filepath.Join(dir, ".sync.lock")
+	if _, err := os.Stat(want); err != nil {
+		t.Fatalf("lock file not at %s: %v", want, err)
+	}
+	info, _ := os.Stat(want)
+	if info.Mode().Perm() != 0o600 {
+		t.Errorf("lock mode = %o, want 0600", info.Mode().Perm())
+	}
+}
+
+func TestAcquireLock_ResolvesSymlinkedDir(t *testing.T) {
+	realDir := t.TempDir()
+	linkDir := filepath.Join(t.TempDir(), "link")
+	if err := os.Symlink(realDir, linkDir); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+	f, err := acquireLock(linkDir, ".sync.lock")
+	if err != nil {
+		t.Fatalf("acquireLock via symlinked dir: %v", err)
+	}
+	defer releaseLock(f)
+
+	if _, err := os.Stat(filepath.Join(realDir, ".sync.lock")); err != nil {
+		t.Errorf("lock file not materialized in real dir: %v", err)
+	}
+}
+
+func TestAcquireLock_RejectsMissingDir(t *testing.T) {
+	if _, err := acquireLock(filepath.Join(t.TempDir(), "does-not-exist"), ".sync.lock"); err == nil {
+		t.Error("expected error for missing dir, got nil")
+	}
+}

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -20,13 +20,33 @@ spec:
       labels:
         app: armies-docs
     spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        runAsGroup: 65532
+        fsGroup: 65532
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: nginx
           image: ghcr.io/petersimmons1972/armies-docs:latest
           imagePullPolicy: Always
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+              add: ["NET_BIND_SERVICE"]
           ports:
             - containerPort: 8080
               name: http
+          volumeMounts:
+            - name: nginx-cache
+              mountPath: /var/cache/nginx
+            - name: nginx-run
+              mountPath: /var/run
+            - name: nginx-tmp
+              mountPath: /tmp
           resources:
             requests:
               cpu: 25m
@@ -46,3 +66,10 @@ spec:
               port: 8080
             initialDelaySeconds: 3
             periodSeconds: 10
+      volumes:
+        - name: nginx-cache
+          emptyDir: {}
+        - name: nginx-run
+          emptyDir: {}
+        - name: nginx-tmp
+          emptyDir: {}

--- a/k8s/github-runner.yaml
+++ b/k8s/github-runner.yaml
@@ -16,9 +16,17 @@ spec:
         app: github-runner
     spec:
       serviceAccountName: github-runner
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - name: runner
         image: myoung34/github-runner:latest
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: ["ALL"]
         env:
         - name: REPO_URL
           value: https://github.com/petersimmons1972/armies


### PR DESCRIPTION
## Summary

Tier A of the 2026-04-22 security-scan triage. Low-risk mechanical fixes and YAML hardening. Tier B/C issues are tracked separately per the plan.

Closes #51 · Closes #53 · Closes #54 · Closes #56

### Changes

| Issue | Change |
|---|---|
| #54 | Tighten permissions at 8 call sites: dirs 0755→0700, files 0644→0600 in `cmd/{init,record,seed,research}.go` |
| #56 | `acquireLock` now takes `(dir, name)`; resolves symlinks on dir, checks containment, rejects separator in name. `releaseLock` now logs Flock/Close errors instead of discarding them. New `sync_lock_unix_test.go` covers the guard. |
| #53 | `k8s/deployment.yaml`: `runAsNonRoot`, `readOnlyRootFilesystem`, `allowPrivilegeEscalation: false`, drop ALL caps + add `NET_BIND_SERVICE`, `seccompProfile: RuntimeDefault`, emptyDir volumes for `/var/cache/nginx`, `/var/run`, `/tmp`. `k8s/github-runner.yaml`: pod-level `runAsNonRoot` + RuntimeDefault, container-level `allowPrivilegeEscalation: false` + drop ALL caps. Rootfs left writable on the runner — it writes work dirs by design; separate RBAC narrowing is #49. |
| #51 | Added invariant comment to `docker/nginx-docs.conf`. Config verified static-only (try_files only; no proxy_pass/autoindex/CGI). |

### What this PR does NOT address

- **#47 / #48** — path-resolution hardening in `ResolveAgentPath` and the `caseInsensitiveSearch` fallback. Ships next as PR-2.
- **#50** — go stdlib 1.22 → 1.24 bump + govulncheck. PR-3.
- **#52** — `RunGit` argument-injection audit. PR-4.
- **#49 / #55** — runner RBAC narrowing and image digest pinning. Needs RBAC inventory design pass; PR-5.
- **#46** — RFC, parked.

### Test plan

- [x] `go build ./...` clean
- [x] `go test ./...` all packages pass (new tests in `internal/sync`)
- [x] `kubectl apply --dry-run=client -f k8s/deployment.yaml -f k8s/github-runner.yaml` — configured
- [ ] After deploy: verify `armies-docs` pod starts with `readOnlyRootFilesystem: true` and serves `/healthz`
- [ ] After deploy: verify `github-runner` pod starts (rootfs writable but non-root, dropped caps)

🤖 Generated with [Claude Code](https://claude.com/claude-code)