### PR TITLE
security: harden ResolveAgentPath against symlink escape + re-validate fallback

### DIFF
--- a/cmd/spawn.go
+++ b/cmd/spawn.go
@@ -45,13 +45,19 @@ func NewSpawnCommand() *cobra.Command {
 				return err
 			}
 
-			// Check existence; fall back to case-insensitive search
+			// Check existence; fall back to case-insensitive search.
+			// The fallback result MUST be re-validated with EnsureContained —
+			// ResolveAgentPath's guard ran only against the first candidate.
 			if _, statErr := os.Stat(profilePath); statErr != nil {
 				found := caseInsensitiveSearch(pdir, agentName)
 				if found == "" {
 					return fmt.Errorf("profile not found: %s (searched in %s)", agentName, pdir)
 				}
-				profilePath = found
+				resolved, err := profiles.EnsureContained(pdir, found)
+				if err != nil {
+					return fmt.Errorf("case-insensitive match %s failed containment check: %w", found, err)
+				}
+				profilePath = resolved
 			}
 
 			// Determine role from --role flag

--- a/internal/profiles/parser.go
+++ b/internal/profiles/parser.go
@@ -20,13 +20,27 @@ const (
 )
 
 // ResolveAgentPath constructs the path for agentName inside profilesDir and
-// returns an error if the resolved path would escape profilesDir (path
-// traversal guard).
+// returns an error if the resolved path would escape profilesDir.
 //
-// Note: this is a lexical check only and does not resolve symlinks. A symlink
-// inside profilesDir pointing outside it will pass this check. This is
-// acceptable when profilesDir is user-controlled (e.g., ~/.armies/profiles).
+// The guard is two-layered:
+//  1. Lexical: filepath.Rel-based containment against the absolute profilesDir.
+//  2. Symbolic: if the candidate file exists, filepath.EvalSymlinks is applied
+//     to both profilesDir and the candidate, and containment is re-checked.
+//     This rejects a symlink inside profilesDir that points outside it.
+//
+// If the candidate does not yet exist (which is common — ResolveAgentPath is
+// also called as a pre-read validation step), only the lexical check runs.
+// Callers that read the returned path MUST treat the returned path as
+// untrusted-until-read if they also accept input that may name non-existent
+// profiles; use EnsureContained on any path they compute via alternate means
+// (e.g., case-insensitive lookup) before opening it.
 func ResolveAgentPath(profilesDir, agentName string) (string, error) {
+	if agentName == "" {
+		return "", fmt.Errorf("agent name is empty")
+	}
+	if strings.ContainsAny(agentName, "/\\") {
+		return "", fmt.Errorf("agent name %q resolves outside profiles directory", agentName)
+	}
 	absDir, err := filepath.Abs(profilesDir)
 	if err != nil {
 		return "", fmt.Errorf("resolving profiles directory: %w", err)
@@ -38,14 +52,60 @@ func ResolveAgentPath(profilesDir, agentName string) (string, error) {
 		return "", fmt.Errorf("resolving candidate path: %w", err)
 	}
 
-	// filepath.Rel returns a path beginning with ".." when absCandidate is
-	// outside absDir.
-	rel, err := filepath.Rel(absDir, absCandidate)
-	if err != nil || strings.HasPrefix(rel, "..") {
+	if !lexicallyContained(absDir, absCandidate) {
 		return "", fmt.Errorf("agent name %q resolves outside profiles directory", agentName)
 	}
 
+	// Symbolic containment: only possible if the file exists. If it does not
+	// exist yet, the lexical guard above is sufficient — no symlink to follow.
+	if _, statErr := os.Lstat(absCandidate); statErr == nil {
+		resolved, err := EnsureContained(absDir, absCandidate)
+		if err != nil {
+			return "", err
+		}
+		return resolved, nil
+	}
+
 	return absCandidate, nil
+}
+
+// EnsureContained resolves base and candidate via filepath.EvalSymlinks and
+// confirms the resolved candidate is lexically contained within the resolved
+// base. Returns the resolved candidate path on success. Exported so callers
+// that compute profile paths by alternate means (e.g., case-insensitive
+// lookup) can re-validate before opening the file.
+func EnsureContained(base, candidate string) (string, error) {
+	resolvedBase, err := filepath.EvalSymlinks(base)
+	if err != nil {
+		return "", fmt.Errorf("resolve symlinks on base %q: %w", base, err)
+	}
+	resolvedCandidate, err := filepath.EvalSymlinks(candidate)
+	if err != nil {
+		return "", fmt.Errorf("resolve symlinks on candidate %q: %w", candidate, err)
+	}
+	absBase, err := filepath.Abs(resolvedBase)
+	if err != nil {
+		return "", err
+	}
+	absCandidate, err := filepath.Abs(resolvedCandidate)
+	if err != nil {
+		return "", err
+	}
+	if !lexicallyContained(absBase, absCandidate) {
+		return "", fmt.Errorf("path %q resolves outside %q after symlink evaluation", candidate, base)
+	}
+	return absCandidate, nil
+}
+
+func lexicallyContained(base, candidate string) bool {
+	rel, err := filepath.Rel(base, candidate)
+	if err != nil {
+		return false
+	}
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return false
+	}
+	return true
 }
 
 // ParseProfile reads the profile at path and returns:

--- a/internal/profiles/parser_symlink_test.go
+++ b/internal/profiles/parser_symlink_test.go
@@ -1,0 +1,119 @@
+package profiles_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/petersimmons1972/armies/internal/profiles"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestResolveAgentPath_SymlinkOutsideRejected confirms that a symlink placed
+// inside profilesDir that points outside it is rejected by ResolveAgentPath.
+// This is the fix for GitHub issue #47.
+func TestResolveAgentPath_SymlinkOutsideRejected(t *testing.T) {
+	profilesDir := t.TempDir()
+	outsideDir := t.TempDir()
+	outsideFile := filepath.Join(outsideDir, "passwd.md")
+	require.NoError(t, os.WriteFile(outsideFile, []byte("---\n"), 0o600))
+
+	link := filepath.Join(profilesDir, "evil.md")
+	require.NoError(t, os.Symlink(outsideFile, link))
+
+	_, err := profiles.ResolveAgentPath(profilesDir, "evil")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "outside")
+}
+
+// TestResolveAgentPath_SymlinkChainOutsideRejected confirms a two-hop symlink
+// chain that ultimately resolves outside the profiles directory is rejected.
+func TestResolveAgentPath_SymlinkChainOutsideRejected(t *testing.T) {
+	profilesDir := t.TempDir()
+	outsideDir := t.TempDir()
+	outsideFile := filepath.Join(outsideDir, "passwd.md")
+	require.NoError(t, os.WriteFile(outsideFile, []byte("---\n"), 0o600))
+
+	hop1 := filepath.Join(profilesDir, "hop1.md")
+	require.NoError(t, os.Symlink(outsideFile, hop1))
+
+	link := filepath.Join(profilesDir, "chain.md")
+	require.NoError(t, os.Symlink(hop1, link))
+
+	_, err := profiles.ResolveAgentPath(profilesDir, "chain")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "outside")
+}
+
+// TestResolveAgentPath_SymlinkInsideAccepted confirms a symlink whose final
+// target is inside profilesDir is still accepted.
+func TestResolveAgentPath_SymlinkInsideAccepted(t *testing.T) {
+	profilesDir := t.TempDir()
+	real := filepath.Join(profilesDir, "real.md")
+	require.NoError(t, os.WriteFile(real, []byte("---\n"), 0o600))
+
+	alias := filepath.Join(profilesDir, "alias.md")
+	require.NoError(t, os.Symlink(real, alias))
+
+	got, err := profiles.ResolveAgentPath(profilesDir, "alias")
+	require.NoError(t, err)
+	// EvalSymlinks on an existing target returns the canonical real path.
+	wantReal, err := filepath.EvalSymlinks(real)
+	require.NoError(t, err)
+	assert.Equal(t, wantReal, got)
+}
+
+// TestResolveAgentPath_NonexistentUsesLexicalOnly confirms that when the file
+// does not yet exist, the lexical guard is sufficient (no EvalSymlinks call).
+// This preserves the existing contract for pre-read validation (e.g., in
+// `armies record` before the file is created).
+func TestResolveAgentPath_NonexistentUsesLexicalOnly(t *testing.T) {
+	profilesDir := t.TempDir()
+	got, err := profiles.ResolveAgentPath(profilesDir, "future-agent")
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join(profilesDir, "future-agent.md"), got)
+}
+
+// TestResolveAgentPath_SeparatorInNameRejected confirms names containing a
+// path separator are rejected up-front, independent of containment logic.
+func TestResolveAgentPath_SeparatorInNameRejected(t *testing.T) {
+	profilesDir := t.TempDir()
+	for _, name := range []string{"a/b", `a\b`} {
+		_, err := profiles.ResolveAgentPath(profilesDir, name)
+		require.Error(t, err, "name %q must be rejected", name)
+		assert.Contains(t, err.Error(), "outside profiles directory")
+	}
+	_, err := profiles.ResolveAgentPath(profilesDir, "")
+	require.Error(t, err)
+}
+
+// TestEnsureContained_RejectsSymlinkEscape confirms the exported helper (used
+// by cmd/spawn.go to re-validate case-insensitive fallback results) rejects a
+// path that resolves outside base after symlink evaluation. Fix for issue #48.
+func TestEnsureContained_RejectsSymlinkEscape(t *testing.T) {
+	profilesDir := t.TempDir()
+	outsideDir := t.TempDir()
+	outsideFile := filepath.Join(outsideDir, "passwd.md")
+	require.NoError(t, os.WriteFile(outsideFile, []byte("---\n"), 0o600))
+
+	link := filepath.Join(profilesDir, "FOO.md")
+	require.NoError(t, os.Symlink(outsideFile, link))
+
+	_, err := profiles.EnsureContained(profilesDir, link)
+	require.Error(t, err)
+}
+
+// TestEnsureContained_AcceptsContainedPath confirms the happy path through
+// the exported helper.
+func TestEnsureContained_AcceptsContainedPath(t *testing.T) {
+	profilesDir := t.TempDir()
+	real := filepath.Join(profilesDir, "Agent.md")
+	require.NoError(t, os.WriteFile(real, []byte("---\n"), 0o600))
+
+	got, err := profiles.EnsureContained(profilesDir, real)
+	require.NoError(t, err)
+	wantReal, err := filepath.EvalSymlinks(real)
+	require.NoError(t, err)
+	assert.Equal(t, wantReal, got)
+}


### PR DESCRIPTION
## Summary

Closes #47 · Closes #48.

`ResolveAgentPath` (`internal/profiles/parser.go`) previously performed a lexical-only containment check and documented the gap explicitly. A symlink placed inside the profiles directory that pointed outside it bypassed the guard:

```bash
ln -s /etc/passwd ~/.armies/profiles/evil.md
armies spawn evil --role specialist
# pre-patch: emits /etc/passwd content as "profile"
# post-patch: Error: path "…/evil.md" resolves outside "…" after symlink evaluation
```

`cmd/spawn.go` compounded the risk: the case-insensitive search fallback (`caseInsensitiveSearch` on profile-not-found) assigned its result to `profilePath` with no re-validation — the only traversal guard ran against the first candidate, not the fallback result. Safe today by implementation detail (`ReadDir` yields direct children), but the contract was wrong.

### Fix

- `ResolveAgentPath` now calls `filepath.EvalSymlinks` on both `profilesDir` and the candidate (when the candidate exists) and re-checks containment after resolution. Non-existent candidates keep the lexical-only path, preserving the pre-read validation contract used by `armies record` etc.
- New exported `EnsureContained(base, candidate)` helper encapsulates the symlink-aware guard. Any caller that computes a profile path by alternate means re-validates through it.
- `cmd/spawn.go` routes the case-insensitive fallback through `EnsureContained` before assignment.
- Agent names containing `/`, `\\`, or empty strings are rejected up-front with the same "outside profiles directory" message.

### Test plan

- [x] `go build ./...` clean
- [x] `go test ./...` — all packages pass (6 new tests in `internal/profiles`)
- [x] Manual repro (`ln -s /etc/passwd …/evil.md && armies spawn evil --role specialist`) → rejected
- New tests: symlink-outside, symlink-chain-outside, symlink-inside-accepted, nonexistent-lexical-only, separator-rejected, `EnsureContained` reject + accept

🤖 Generated with [Claude Code](https://claude.com/claude-code)