### PR TITLE
security: validate git remote URLs + add -- separator in RunGit call sites

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/petersimmons1972/armies/internal/config"
 	"github.com/petersimmons1972/armies/internal/gitops"
@@ -83,8 +84,19 @@ func NewInitCommand() *cobra.Command {
 }
 
 // runInitGit runs git init and sets (or updates) remote origin in dir.
+// Both dir and remoteURL are validated before being passed to git to avoid
+// flag-injection (dir or URL starting with "-") and git-config substring
+// abuse (--upload-pack=, core.gitProxy=, …).
 func runInitGit(cmd *cobra.Command, dir, remoteURL string) error {
-	_, stderr, err := gitops.RunGit(".", "init", dir)
+	if err := gitops.ValidateRemoteURL(remoteURL); err != nil {
+		return fmt.Errorf("refusing to set origin: %w", err)
+	}
+	if strings.HasPrefix(dir, "-") {
+		return fmt.Errorf("refusing to git-init %q: path starts with '-'", dir)
+	}
+
+	// `git init -- dir` forces dir to be treated as a positional argument.
+	_, stderr, err := gitops.RunGit(".", "init", "--", dir)
 	if err != nil {
 		return fmt.Errorf("git init failed: %s", stderr)
 	}

--- a/internal/gitops/gitops.go
+++ b/internal/gitops/gitops.go
@@ -2,12 +2,23 @@ package gitops
 
 import (
 	"bytes"
+	"fmt"
+	"net/url"
 	"os/exec"
 	"strings"
 )
 
 // RunGit runs git with args in dir. Returns trimmed stdout, stderr, and error.
 // An error is returned if the command exits non-zero.
+//
+// IMPORTANT — caller contract: args MUST NOT include any element derived from
+// untrusted input unless it has been validated. Git has several flags that
+// invoke attacker-controlled binaries (`--upload-pack=`, `--receive-pack=`,
+// `-c core.gitProxy=…`, `-c core.pager=…`, `-c core.sshCommand=…`) and will
+// happily interpret a value that starts with `-` as a flag. When passing
+// user-supplied URLs, branches, or paths, use ValidateRemoteURL / ValidateRef
+// / a path containment check first, and where the arg is a positional that
+// follows subcommand-specific options, pass `--` before it.
 func RunGit(dir string, args ...string) (stdout, stderr string, err error) {
 	cmd := exec.Command("git", args...)
 	cmd.Dir = dir
@@ -16,4 +27,67 @@ func RunGit(dir string, args ...string) (stdout, stderr string, err error) {
 	cmd.Stderr = &errBuf
 	err = cmd.Run()
 	return strings.TrimSpace(outBuf.String()), strings.TrimSpace(errBuf.String()), err
+}
+
+// dangerousArgSubstrings rejects any occurrence of a git flag whose value is
+// an attacker-controlled binary. These are not reachable through documented
+// remote-URL parsing but appear as literal substrings when an attacker injects
+// a crafted URL into argv.
+var dangerousArgSubstrings = []string{
+	"--upload-pack=",
+	"--receive-pack=",
+	"core.gitproxy=",
+	"core.pager=",
+	"core.sshcommand=",
+	"core.fsmonitor=",
+}
+
+// ValidateRemoteURL validates a git remote URL as safe to pass to RunGit.
+// Allowed forms: `https://…`, `ssh://…`, SCP-style `git@host:path`.
+// Rejects:
+//   - empty input
+//   - values starting with `-` (would be interpreted as a flag by git)
+//   - any value containing a dangerous git-config substring that could
+//     invoke an attacker-controlled binary (--upload-pack=, -c core.pager=, …)
+//   - http://, file://, ext:: and other non-network schemes that could be
+//     abused as SSRF or ext-cmd execution vectors
+func ValidateRemoteURL(rawURL string) error {
+	s := strings.TrimSpace(rawURL)
+	if s == "" {
+		return fmt.Errorf("remote url is empty; set https:// or git@ URL")
+	}
+	if strings.HasPrefix(s, "-") {
+		return fmt.Errorf("remote url %q starts with '-'; would be interpreted as a git flag", s)
+	}
+	lower := strings.ToLower(s)
+	for _, bad := range dangerousArgSubstrings {
+		if strings.Contains(lower, bad) {
+			return fmt.Errorf("remote url contains disallowed substring %q", bad)
+		}
+	}
+
+	if strings.HasPrefix(s, "git@") {
+		// SCP-style SSH: "git@host:path". Validate it has the colon separator
+		// and no whitespace that could enable argv splitting downstream.
+		if !strings.Contains(s, ":") {
+			return fmt.Errorf("scp-style remote url %q missing ':' separator", s)
+		}
+		if strings.ContainsAny(s, " \t\n\r") {
+			return fmt.Errorf("remote url %q contains whitespace", s)
+		}
+		return nil
+	}
+
+	u, err := url.Parse(s)
+	if err != nil {
+		return fmt.Errorf("malformed remote url: %w", err)
+	}
+	scheme := strings.ToLower(u.Scheme)
+	if scheme != "https" && scheme != "ssh" {
+		return fmt.Errorf("remote url uses disallowed protocol %q; only https://, ssh://, git@ allowed", scheme)
+	}
+	if u.Host == "" {
+		return fmt.Errorf("remote url %q has no host", s)
+	}
+	return nil
 }

--- a/internal/gitops/validate_remote_url_test.go
+++ b/internal/gitops/validate_remote_url_test.go
@@ -1,0 +1,86 @@
+package gitops_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/petersimmons1972/armies/internal/gitops"
+)
+
+func TestValidateRemoteURL_AllowedForms(t *testing.T) {
+	allowed := []string{
+		"https://github.com/owner/repo.git",
+		"https://github.com/owner/repo",
+		"ssh://git@github.com/owner/repo.git",
+		"git@github.com:owner/repo.git",
+		"git@example.org:group/sub/repo",
+	}
+	for _, u := range allowed {
+		if err := gitops.ValidateRemoteURL(u); err != nil {
+			t.Errorf("expected %q to be allowed, got error: %v", u, err)
+		}
+	}
+}
+
+func TestValidateRemoteURL_RejectsEmpty(t *testing.T) {
+	for _, u := range []string{"", "  ", "\t\n"} {
+		if err := gitops.ValidateRemoteURL(u); err == nil {
+			t.Errorf("expected empty input %q to be rejected", u)
+		}
+	}
+}
+
+func TestValidateRemoteURL_RejectsFlagInjection(t *testing.T) {
+	// A value that starts with '-' would be consumed by git as a flag rather
+	// than a positional URL argument — must be refused.
+	for _, u := range []string{"-", "--upload-pack=/tmp/pwn", "-c", "-core.pager=curl"} {
+		err := gitops.ValidateRemoteURL(u)
+		if err == nil {
+			t.Errorf("expected %q to be rejected as flag injection", u)
+		}
+	}
+}
+
+func TestValidateRemoteURL_RejectsDangerousSubstrings(t *testing.T) {
+	// Even embedded in a URL-ish form, these config keys must be refused.
+	cases := []string{
+		"https://example.com/repo.git --upload-pack=/tmp/pwn",
+		"https://example.com/repo?core.pager=/tmp/pwn",
+		"https://example.com/repo#core.gitproxy=/tmp/pwn",
+		"git@host:repo core.sshcommand=/tmp/pwn",
+		"https://example.com/?core.fsmonitor=/tmp/pwn",
+	}
+	for _, u := range cases {
+		err := gitops.ValidateRemoteURL(u)
+		if err == nil {
+			t.Errorf("expected %q to be rejected for dangerous substring", u)
+			continue
+		}
+		if !strings.Contains(err.Error(), "disallowed substring") &&
+			!strings.Contains(err.Error(), "whitespace") {
+			t.Errorf("unexpected error for %q: %v", u, err)
+		}
+	}
+}
+
+func TestValidateRemoteURL_RejectsDisallowedSchemes(t *testing.T) {
+	for _, u := range []string{
+		"http://example.com/repo.git",
+		"file:///etc/passwd",
+		"ext::sh -c pwn",
+		"ftp://example.com/repo",
+	} {
+		if err := gitops.ValidateRemoteURL(u); err == nil {
+			t.Errorf("expected %q to be rejected by scheme allow-list", u)
+		}
+	}
+}
+
+func TestValidateRemoteURL_RejectsMalformedScp(t *testing.T) {
+	// git@host without ':' is not SCP-style and must not be silently accepted.
+	for _, u := range []string{"git@host", "git@", "git@ host:repo"} {
+		if err := gitops.ValidateRemoteURL(u); err == nil {
+			t.Errorf("expected %q to be rejected", u)
+		}
+	}
+}

--- a/internal/sync/sync.go
+++ b/internal/sync/sync.go
@@ -2,7 +2,6 @@ package sync
 
 import (
 	"fmt"
-	"net/url"
 	"strings"
 
 	"github.com/petersimmons1972/armies/internal/gitops"
@@ -29,25 +28,15 @@ func errResult(msg string) SyncResult {
 	return SyncResult{Error: &s}
 }
 
-// ValidateRemoteURL validates that the URL is non-empty and uses an allowed
-// protocol (https, ssh, or git@ SCP). Rejects empty, http://, file://, etc.
+// ValidateRemoteURL delegates to gitops.ValidateRemoteURL, which enforces
+// protocol allow-list plus flag-injection and git-config-substring defenses.
+// Preserved here as a thin wrapper for historical call sites and to keep the
+// "remote_url is empty" phrasing that references the config file.
 func ValidateRemoteURL(rawURL string) error {
-	s := strings.TrimSpace(rawURL)
-	if s == "" {
+	if strings.TrimSpace(rawURL) == "" {
 		return fmt.Errorf("remote_url is empty; set https:// or git@ URL in ~/.armies/config.yaml")
 	}
-	if strings.HasPrefix(s, "git@") {
-		return nil // SCP-style SSH is valid
-	}
-	u, err := url.Parse(s)
-	if err != nil {
-		return fmt.Errorf("malformed remote_url: %w", err)
-	}
-	scheme := strings.ToLower(u.Scheme)
-	if scheme != "https" && scheme != "ssh" {
-		return fmt.Errorf("remote_url uses disallowed protocol %q; only https://, ssh://, git@ allowed", scheme)
-	}
-	return nil
+	return gitops.ValidateRemoteURL(rawURL)
 }
 
 // Sync pulls then pushes the armies directory.


### PR DESCRIPTION
## Summary

Closes #52.

\`RunGit\` invokes git directly, so shell injection is off the table — but git itself accepts flags that execute attacker-controlled binaries:

| Flag | Effect |
|---|---|
| \`--upload-pack=<path>\` | Runs \`<path>\` on clone/fetch |
| \`--receive-pack=<path>\` | Runs \`<path>\` on push |
| \`-c core.gitProxy=<cmd>\` | Runs \`<cmd>\` as network proxy |
| \`-c core.pager=<cmd>\` | Runs \`<cmd>\` as pager |
| \`-c core.sshCommand=<cmd>\` | Runs \`<cmd>\` as SSH |
| \`-c core.fsmonitor=<cmd>\` | Runs \`<cmd>\` as fsmonitor |

### Audit result

Only \`cmd/init.go\` passes user-controlled data (\`dir\`, \`remoteURL\`) to \`RunGit\`. \`internal/sync/sync.go\` uses hardcoded \`\"origin\"\` / \`\"master\"\` and config-derived \`ArmiesDir\`.

### Fix

- \`gitops.ValidateRemoteURL\` is now the canonical validator. Rejects: empty, leading \`-\`, the six dangerous git-config substrings (case-insensitive), non-https/ssh/SCP schemes, malformed SCP-style URLs, URLs without a host.
- \`cmd/init.go\` validates \`remoteURL\` up-front and refuses \`dir\` starting with \`-\`. \`git init dir\` is now \`git init -- dir\`.
- \`sync.ValidateRemoteURL\` delegates to \`gitops.ValidateRemoteURL\`.
- \`RunGit\` documents the caller contract: validated input only, \`--\` before untrusted positionals.

### Test plan

- [x] \`go build ./...\` clean
- [x] \`go test ./...\` — all packages pass (6 new test cases in \`internal/gitops\`)
- New tests cover: allowed forms, empty rejection, flag injection (\`-\` prefix), the six dangerous substrings, disallowed schemes (http, file, ext::, ftp), malformed SCP forms.

### What this PR does NOT address

- #50 (Go stdlib bump) — follow-up PR, needs govulncheck.
- #49 / #55 — supply-chain (image digest + RBAC narrowing), separate strategic PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)